### PR TITLE
update sha256 for Filebot 4.8.2 - fixes #49801

### DIFF
--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -1,6 +1,6 @@
 cask 'filebot' do
   version '4.8.2'
-  sha256 '20cd5761bc51a213d31ab035f28831fb0e4d9097727a80e32f2d477fcccb0525'
+  sha256 '1392977186771075a23ff9758fa5f4f3eb1229df0674a43ec7cb8b8a8b737777'
 
   url "https://get.filebot.net/filebot/FileBot_#{version}/FileBot_#{version}.app.tar.xz"
   appcast 'https://app.filebot.net/update.xml'


### PR DESCRIPTION
The sha256 for the file, hosted at the same domain as `FileBot_4.8.2.app.tar.xz` matches the `Actual` sha256:

```bash
$ curl https://get.filebot.net/filebot/FileBot_4.8.2/FileBot_4.8.2.app.tar.xz.sha256
1392977186771075a23ff9758fa5f4f3eb1229df0674a43ec7cb8b8a8b737777
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
